### PR TITLE
The length of the image field of thumbnail not match with the image field of Image model

### DIFF
--- a/django_images/models.py
+++ b/django_images/models.py
@@ -74,7 +74,8 @@ class ThumbnailManager(models.Manager):
 class Thumbnail(models.Model):
     original = models.ForeignKey(Image)
     image = models.ImageField(upload_to=thumbnail_upload_to,
-            height_field='height', width_field='width')
+            height_field='height', width_field='width',
+            max_length=255)
     size = models.CharField(max_length=100)
     height = models.PositiveIntegerField(default=0, editable=False)
     width = models.PositiveIntegerField(default=0, editable=False)


### PR DESCRIPTION
This works well when the filename is short but with a (not too much) long filename the thumbnail generation fails.
