### PR TITLE
remove "/by-md5/" prefix from image path/make path customizable

### DIFF
--- a/django_images/settings.py
+++ b/django_images/settings.py
@@ -1,3 +1,4 @@
 from django.conf import settings
 
+IMAGE_PATH = getattr(settings, 'IMAGE_PATH', None)
 IMAGE_SIZES = getattr(settings, 'IMAGE_SIZES', {})


### PR DESCRIPTION
the "/by-md5/" path prefix doesn't make much sense, md5 being the only hash being used, so I'd like to propose it's removal or, if for some reason that's not feasible, I'd like to propose that something similar to PHOTOLOGUE_PATH [1] is used. I'll probably write a patch anyway "soonish", as I don't see a clean way of changing upload_to without upstream code supporting it.

I'd probably suggest a settings.IMAGES_PATH that behaves just as photologue counterpart, and keeping current behaviour by providing the default upload_to similar to:

``` py
    def upload_to(instance, filename, **kwargs):
        image_type = 'original' if isinstance(instance, Image) else 'thumbnail'
        prefix = 'image/{}/by-md5/'.format(image_type)
        [hashing etc.]
```

[1] https://code.google.com/p/django-photologue/wiki/Settings
