### PR TITLE
Get rid of unnecessary dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(name='django-images',
       packages=find_packages(),
       include_package_data=True,
       classifiers=CLASSIFIERS,
-      install_requires=['Django>=1.3', 'pillow>=1.7.8', 'South>=0.7.6'],
+      install_requires=['Django>=1.3', 'pillow>=1.7.8'],
       platforms=['any'],
       zip_safe=False)


### PR DESCRIPTION
`South` is not obligatory for `django-images`. In addtiion projects using django >= 1.7 don't need it at all.